### PR TITLE
do not require hardcoded contacts file

### DIFF
--- a/nvdbapi.py
+++ b/nvdbapi.py
@@ -46,7 +46,7 @@ class nvdbVegnett:
                             'X-Client' : 'nvdbapi.py',
                             'X-Kontaktperson' : 'Anonymous'}
                             
-        # self.update_http_header()
+        self.update_http_header()
                             
         
         self.paginering = { 'antall'         : 1000,     # Hvor mange obj vi henter samtidig.
@@ -294,7 +294,13 @@ class nvdbVegnett:
     def update_http_header(self, filename='nvdbapi-clientinfo.json',
                            client=None, contact=None): 
     
-        if filename:
+        if "X-Client" in os.environ and "X-Kontaktperson" in os.environ:
+            contacts = {
+                    'X-Client': os.environ['X-Client'],
+                    'X-Kontaktperson': os.environ['X-Kontaktperson']
+                    }
+
+        elif filename:
             contactsfile = filename
         
             # Http header info
@@ -445,7 +451,7 @@ class nvdbFagdata(nvdbVegnett):
                         }
         
         # Leser verdier for http header fra JSON-fil
-        # self.update_http_header()
+        self.update_http_header()
         
         # Refresh er lurt, (arver tilstand fra andre instanser). 
         self.refresh()


### PR DESCRIPTION
Per nå er stien til filen med kontaktinformasjon hard kodet. Dvs. brukere må oppdatere malfilen før de tar i bruk pakken.
Denne PR tillater å bruke variabler i steden for. Ulempen er at header ikke ville oppdateres ved  init().
Alternativt kunne man bruke omgivelsesvariabler for å kunne ha den muligheten uten å endre i den nåværende måten skriptet virker på...